### PR TITLE
Use Cint, Int16 to correspond to C header, minor spelling corrections

### DIFF
--- a/src/Lib/blosc2/superchunk.jl
+++ b/src/Lib/blosc2/superchunk.jl
@@ -255,7 +255,7 @@ function blosc2_schunk_delete_chunk(schunk::Ptr{blosc2_schunk}, nchunk)
 end
 
 """
-    blosc2_schunk_reorder_offsets(schunk::Ptr{blosc2_schunk}, offsets_order::Vector{Int32})
+    blosc2_schunk_reorder_offsets(schunk::Ptr{blosc2_schunk}, offsets_order::Vector{Cint})
 
 Reorder the chunk offsets of an existing super-chunk.
 
@@ -269,7 +269,7 @@ Reorder the chunk offsets of an existing super-chunk.
 
 0 if suceeds. Else a negative code is returned.
 """
-function blosc2_schunk_reorder_offsets(schunk::Ptr{blosc2_schunk}, offsets_order::Vector{Int32})
+function blosc2_schunk_reorder_offsets(schunk::Ptr{blosc2_schunk}, offsets_order::Vector{Cint}})
     @ccall lib.blosc2_schunk_reorder_offsets(schunk::Ptr{blosc2_schunk}, offsets_order::Ptr{Cint})::Cint
 end
 

--- a/src/compression/params.jl
+++ b/src/compression/params.jl
@@ -9,7 +9,7 @@ Compression params
         compressor ::Symbol = default_compressor_name()
         level ::UInt8 = 5
         typesize ::Int32 = 8
-        nthreads ::Int32 = 1
+        nthreads ::Int16 = 1
         blocksize ::Int32 = 0
         splitmode ::Bool = false
         filter_pipeline ::FilterPipeline = filter_pipeline(:shuffle)
@@ -31,7 +31,7 @@ struct CompressionParams <: Params
     compressor ::Compressor
     level ::UInt8
     typesize ::Int32
-    nthreads ::Int32
+    nthreads ::Int16
     blocksize ::Int32
     splitmode ::Bool
     filter_pipeline ::FilterPipeline
@@ -94,7 +94,7 @@ Decompression params
 Create decompression parameters
 """
 struct DecompressionParams <: Params
-    nthreads ::Int32
+    nthreads ::Cint
     function DecompressionParams(;nthreads = 1)
         new(nthreads)
     end

--- a/test/lib/superchunk.jl
+++ b/test/lib/superchunk.jl
@@ -28,20 +28,20 @@ end
     lb.blosc2_schunk_free(sc)
 end
 
-@testset "dealing with chuncks" begin
+@testset "dealing with chunks" begin
 
     sc = lb.blosc2_schunk_new()
     n = 10000
-    chuncks_n = 5
-    ch_comp_sizes = Vector{Cint}(undef, chuncks_n)
-    datas = Vector{Vector{Int}}(undef, chuncks_n)
-    for i in 1:chuncks_n
+    chunks_n = 5
+    ch_comp_sizes = Vector{Cint}(undef, chunks_n)
+    datas = Vector{Vector{Int}}(undef, chunks_n)
+    for i in 1:chunks_n
         datas[i] = rand(1:1000, n)
         sz = lb.blosc2_schunk_append_buffer(sc, datas[i], sizeof(datas[i]))
         @test sz > 0
         ch_comp_sizes[i] = sz
     end
-    @test unsafe_load(sc, 1).nchunks == chuncks_n
+    @test unsafe_load(sc, 1).nchunks == chunks_n
 
     buff = lb.blosc2_schunk_get_chunk(sc, 1)
     res = Vector{Int64}(undef, n + 500)
@@ -53,9 +53,9 @@ end
     @test res == datas[2]
 
     chn = lb.blosc2_schunk_append_chunk(sc, buff, true)
-    @test chn == chuncks_n + 1
+    @test chn == chunks_n + 1
 
-    buff = lb.blosc2_schunk_get_chunk(sc, chuncks_n)
+    buff = lb.blosc2_schunk_get_chunk(sc, chunks_n)
     res = Vector{Int64}(undef, n + 500)
     dctx = lb.blosc2_create_dctx()
     dsz = div(lb.blosc2_decompress_ctx(dctx, buff, sizeof(buff), res, sizeof(res)), sizeof(Int64))
@@ -65,7 +65,7 @@ end
     @test res == datas[2]
 
     chn = lb.blosc2_schunk_insert_chunk(sc, 2, buff, true)
-    @test chn == chuncks_n + 2
+    @test chn == chunks_n + 2
 
     buff = lb.blosc2_schunk_get_chunk(sc, 2)
     res = Vector{Int64}(undef, n + 500)
@@ -77,7 +77,7 @@ end
     @test res == datas[2]
 
     chn = lb.blosc2_schunk_update_chunk(sc, 1, buff, true)
-    @test chn == chuncks_n + 2
+    @test chn == chunks_n + 2
 
     buff = lb.blosc2_schunk_get_chunk(sc, 1)
     res = Vector{Int64}(undef, n + 500)
@@ -89,7 +89,7 @@ end
     @test res == datas[2]
 
     chn = lb.blosc2_schunk_delete_chunk(sc, 0)
-    @test chn == chuncks_n + 1
+    @test chn == chunks_n + 1
 
     buff = lb.blosc2_schunk_get_chunk(sc, 0)
     res = Vector{Int64}(undef, n + 500)
@@ -106,18 +106,18 @@ end
 @testset "blosc2_schunk_reorder_offsets" begin
     sc = lb.blosc2_schunk_new()
     n = 10000
-    chuncks_n = 5
-    ch_comp_sizes = Vector{Int32}(undef, chuncks_n)
-    datas = Vector{Vector{Int}}(undef, chuncks_n)
-    for i in 1:chuncks_n
+    chunks_n = 5
+    ch_comp_sizes = Vector{Int32}(undef, chunks_n)
+    datas = Vector{Vector{Int}}(undef, chunks_n)
+    for i in 1:chunks_n
         datas[i] = rand(1:1000, n)
         sz = lb.blosc2_schunk_append_buffer(sc, datas[i], sizeof(datas[i]))
         @test sz > 0
         ch_comp_sizes[i] = sz
     end
-    @test unsafe_load(sc, 1).nchunks == chuncks_n
+    @test unsafe_load(sc, 1).nchunks == chunks_n
 
-    offsets = Int32.(collect(0:chuncks_n-1))
+    offsets = Int32.(collect(0:chunks_n-1))
     offsets[4] = 0
     offsets[1] = 3
 

--- a/test/lib/superchunk.jl
+++ b/test/lib/superchunk.jl
@@ -33,7 +33,7 @@ end
     sc = lb.blosc2_schunk_new()
     n = 10000
     chuncks_n = 5
-    ch_comp_sizes = Vector{Int32}(undef, chuncks_n)
+    ch_comp_sizes = Vector{Cint}(undef, chuncks_n)
     datas = Vector{Vector{Int}}(undef, chuncks_n)
     for i in 1:chuncks_n
         datas[i] = rand(1:1000, n)


### PR DESCRIPTION
This changes a few type definitions to align them closer to the types used in the 2.0.1 header.

This does not fully address #3 .